### PR TITLE
Merge Branch-v1.4BugFix-Qiaoran with Master

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -15,5 +15,8 @@ public class Messages {
     //---------------------EVENT SPECIFIC MESSAGES------------------------
     public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX = "The event index provided is invalid";
     public static final String MESSAGE_EVENTS_LISTED_OVERVIEW = "%1$d event(s) listed!";
+    public static final String MESSAGE_INVALID_INDEX_VALUE = "%s is not a valid index,"
+            + " index should be a non-zero unsigned integer.";
+    public static final String MESSAGE_DUPLICATE_INDEXES = "%s is duplicated, the input indexes must be distinct.";
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -177,16 +177,13 @@ public class ParserUtil {
     public static Date parseDate(String date, boolean isFutureDateAllowed) throws ParseException {
         requireNonNull(date);
         String trimmedDate = date.trim();
-
-        //Check if date format is valid.
-
-        if (!Date.isValidDateFormat(date)) {
+        if (!Date.isValidDateFormat(trimmedDate)) {
             throw new ParseException(Date.MESSAGE_CONSTRAINTS);
+        } else if (!Date.isValidDateValue(trimmedDate)) {
+            throw new ParseException(String.format(Date.MESSAGE_VALUE_CONSTRAINTS, trimmedDate));
         }
-
         //Check if date is after current date and if it is allowed.
-
-        if (Date.isAfterCurrentDate(date) & !isFutureDateAllowed) {
+        if (Date.isAfterCurrentDate(trimmedDate) & !isFutureDateAllowed) {
             throw new ParseException(Date.MESSAGE_CONSTRAINTS_DOB);
         }
         return new Date(trimmedDate);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_DUPLICATE_INDEXES;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INDEX_VALUE;
 import static seedu.address.model.event.StartTime.MESSAGE_FORMAT_CONSTRAINTS;
 import static seedu.address.model.event.StartTime.MESSAGE_VALUE_CONSTRAINTS;
 
@@ -29,9 +31,6 @@ import seedu.address.model.person.Phone;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "%s is not a valid index,"
-            + " index should be a non-zero unsigned integer.";
-
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
@@ -40,7 +39,7 @@ public class ParserUtil {
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+            throw new ParseException(MESSAGE_INVALID_INDEX_VALUE);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
@@ -230,9 +229,13 @@ public class ParserUtil {
         List<Index> indexList = new ArrayList<>();
         for (String index : strIndexes) {
             if (!StringUtil.isNonZeroUnsignedInteger(index)) {
-                throw new ParseException(String.format(MESSAGE_INVALID_INDEX, index));
+                throw new ParseException(String.format(MESSAGE_INVALID_INDEX_VALUE, index));
             }
-            indexList.add(Index.fromOneBased(Integer.parseInt(index)));
+            Index parsedIndex = Index.fromOneBased(Integer.parseInt(index));
+            if (indexList.contains(parsedIndex)) {
+                throw new ParseException(String.format(MESSAGE_DUPLICATE_INDEXES, index));
+            }
+            indexList.add(parsedIndex);
         }
         return indexList;
     }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INDEX_VALUE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
@@ -42,7 +42,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_VALUE, ()
             -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 


### PR DESCRIPTION
the error messages for all the commands of the format `COMMAND_WORD INDEX PREFIX/CONTENT` (when INDEX is 0) are all `Invalid command format ...` instead of `index must be a non-zero integer ...`

E.g. `editEvent 0 p/discount`, `editPerson 0 g/f`, `deletePerson 0`, `mailEvent 0`, etc.  Therefore issue #239 is not fixed